### PR TITLE
update mobc to 0.8.1

### DIFF
--- a/mobc-bolt/Cargo.toml
+++ b/mobc-bolt/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.0"
 bolt-client = { path = "../bolt-client", version = "0.11.0", features = ["tokio-stream"] }
-mobc = "0.7.0"
+mobc = "0.8.1"
 tokio = { version = "1.23.0", features = ["io-util", "net"] }
 tokio-util = { version = "0.7.0", features = ["compat"] }
 


### PR DESCRIPTION
Updates mobc to the latest 0.8.1 release https://github.com/importcjj/mobc/blob/main/CHANGELOG.md